### PR TITLE
feat : 메인 페이지 시간 필터 기능 구현

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,33 +1,46 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const SearchBar = () => {
+const SearchBar = ({ selectedTime, selectedCategory }) => {
   const [query, setQuery] = useState('');
   const navigate = useNavigate();
 
-  const handleSearch = (e) => {
-    if (query.trim() === '') return;
-    navigate(`/stores?name=${encodeURIComponent(query)}`);
-    setQuery('');
+  const handleSearch = () => {
+    const params = new URLSearchParams();
+
+    if (query.trim()) {
+      params.append('name', query.trim());
+    }
+    if (selectedTime) {
+      params.append('time', selectedTime);
+    }
+    if (selectedCategory) {
+      params.append('category', selectedCategory);
+    }
+
+    navigate(`/stores?${params.toString()}`);
   };
 
   return (
     <div className="w-full h-[40px] bg-white px-[10px] py-[10px] justify-between items-center rounded-[20px] flex mt-[16px]">
       <input
-        id="search"
         type="text"
         value={query}
         placeholder="지금 떠오르는 메뉴를 검색해보세요"
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            handleSearch(e);
+            handleSearch();
           }
         }}
-        className="flex w-full"
+        className="flex w-full outline-none"
       />
       <button type="button" onClick={handleSearch}>
-        <img src="/Search.png" className="flex content-end cursor-pointer" />
+        <img
+          src="http://localhost:3000/Search.png"
+          className="flex content-end cursor-pointer"
+          alt="search icon"
+        />
       </button>
     </div>
   );

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,11 +1,20 @@
-// src/pages/Main.jsx
-
-import React from 'react';
-import SearchBar from '../components/SearchBar';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import SearchBar from '../components/SearchBar';
 
 const Main = () => {
   const navigate = useNavigate();
+
+  const [selectedTime, setSelectedTime] = useState(null);
+  const [selectedCategory, setSelectedCategory] = useState(null);
+
+  const handleTimeSelect = (timeRange) => {
+    setSelectedTime((prev) => (prev === timeRange ? null : timeRange));
+  };
+
+  const handleCategorySelect = (category) => {
+    setSelectedCategory((prev) => (prev === category ? null : category));
+  };
 
   const goToStores = () => {
     navigate('/stores');
@@ -26,29 +35,39 @@ const Main = () => {
           <p>좋은 아침이에요</p>
           <p>오늘은 어디에서 시작할까요?</p>
         </div>
-        <SearchBar />
+
+        <SearchBar
+          selectedTime={selectedTime}
+          selectedCategory={selectedCategory}
+        />
 
         {/* 토글 항목 */}
         <div className="flex flex-row justify-between mt-[16px]">
           {/* Time Group */}
           <div className="flex flex-row items-center gap-[6px] mt-[16px]">
             <p className="text-[12px]">Time</p>
-            <button className="bg-white p-2 w-fit h-[20px] rounded-[20px] flex justify-center items-center hover:cursor-pointer text-[12px]">
-              now
-            </button>
-            <button className="bg-white w-fit p-2 h-[20px] rounded-[20px] flex justify-center items-center hover:cursor-pointer text-[12px]">
+            <button
+              onClick={() => handleTimeSelect('6-7')}
+              className={`p-2 w-fit h-[20px] rounded-[20px] flex justify-center items-center text-[12px] ${selectedTime === '6-7' ? 'bg-yellow-400 font-bold' : 'bg-white'}`}
+            >
               6
             </button>
-            <button className="bg-white w-fit p-2 h-[20px] rounded-[20px] flex justify-center items-center hover:cursor-pointer text-[12px]">
+            <button
+              onClick={() => handleTimeSelect('7-8')}
+              className={`p-2 w-fit h-[20px] rounded-[20px] flex justify-center items-center text-[12px] ${selectedTime === '7-8' ? 'bg-yellow-400 font-bold' : 'bg-white'}`}
+            >
               7
             </button>
-            <button className="bg-white w-fit p-2 h-[20px] rounded-[20px] flex justify-center items-center hover:cursor-pointer text-[12px]">
+            <button
+              onClick={() => handleTimeSelect('8-9')}
+              className={`p-2 w-fit h-[20px] rounded-[20px] flex justify-center items-center text-[12px] ${selectedTime === '8-9' ? 'bg-yellow-400 font-bold' : 'bg-white'}`}
+            >
               8
             </button>
           </div>
 
           {/* Place Group */}
-          <div className="flex flex-row items-center gap-[6px] mt-[16px]">
+          <div className="flex flex-row items-center gap-[6px]">
             <p className="text-[12px]">Place</p>
             <button className="bg-white p-2 w-fit h-[20px] rounded-[20px] flex justify-center items-center hover:cursor-pointer text-[12px]">
               my
@@ -75,10 +94,9 @@ const Main = () => {
       </div>
 
       {/* 쿠폰 박스 */}
-      <div className="border-[#FCE6A4] border-3 rounded-[20px] mx-[30px] my-[16px] p-[18px] flex flex-col">
+      <div className="border-[#FCE6A4] border-2 rounded-[20px] mx-[30px] my-[16px] p-[18px] flex flex-col">
         <p className="font-bold text-[20px]">윤서님 주변의 쿠폰</p>
         <div className="flex flex-row justify-between items-center">
-          {/* 이미지 */}
           <div className="flex flex-row gap-[16px] ">
             <img
               src="/hdcafe.png"
@@ -90,38 +108,36 @@ const Main = () => {
               alt="coupon"
               className="w-[120px] h-[120px] rounded-[15px] object-cover mt-[16px]"
             />
-            <p className="flex content-end items-center text-[12px] font-bold">
-              더보기
-            </p>
+            <p className="flex items-end text-[12px] font-bold">더보기</p>
           </div>
         </div>
       </div>
 
       {/* HOT 얼리버드 */}
-      <div className="border-[#FCE6A4] border-3 rounded-[20px] mx-[30px] my-[16px] p-[18px] flex flex-col">
+      <div className="border-[#FCE6A4] border-2 rounded-[20px] mx-[30px] my-[16px] p-[18px] flex flex-col">
         <p className="font-bold text-[20px]">오늘의 HOT🔥 얼리버드</p>
-        <div className="flex flex-row content-center items-center">
+        <div className="flex flex-row items-center">
           <img
             src="/gabiae.png"
             alt="hot"
             className="w-[120px] h-[120px] rounded-[15px] object-cover mt-[16px]"
           />
-          <div className="pl-[16px]">
+          <div className="pl-[16px] flex-grow">
             <div className="flex flex-row items-center mt-[16px]">
               <p className="text-[20px] font-black">가비애</p>
-              <p className="text-[20px]">⭐4.9</p>
+              <p className="text-[20px] ml-2">⭐4.9</p>
             </div>
             <p className="text-[14px] font-medium"># 모든 자리에 콘센트 있음</p>
             <p className="text-[14px] font-medium"># 24시간 오픈</p>
             <p className="text-[12px]">홍대입구역에서 5분</p>
-            <button
-              className="bg-[#FCE6A4] w-full p-2 h-[30px] rounded-[30px] flex justify-center items-center hover:cursor-pointer text-[14px] font-bold mt-[6px]"
-              onClick={goToStores}
-            >
-              얼리버드 되기
-            </button>
           </div>
         </div>
+        <button
+          className="bg-[#FCE6A4] w-full p-2 h-[30px] rounded-[30px] flex justify-center items-center hover:cursor-pointer text-[14px] font-bold mt-[6px]"
+          onClick={goToStores}
+        >
+          얼리버드 되기
+        </button>
       </div>
     </>
   );

--- a/src/pages/Stores.jsx
+++ b/src/pages/Stores.jsx
@@ -1,105 +1,106 @@
-// src/pages/Stores.jsx
-
 import { useEffect, useMemo } from 'react';
-import { stores } from '../data/mockStores'; // 전체 Mock Data 불러오기
-import StoreCard from '../components/StoreCard';
 import {
   useNavigate,
   useOutletContext,
   useSearchParams,
 } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import instance from '../apis/axios';
-
-// 한글/대소문자/공백 정규화
-const normalize = (s = '') =>
-  s.normalize('NFC').toLowerCase().replace(/\s+/g, '');
-const matches = (name, q) => normalize(name).includes(normalize(q));
+import { stores } from '../data/mockStores'; // 1. Mock Data를 다시 import 합니다.
+import { fetchAllStores, getStoresByName } from '../apis/stores';
+import StoreCard from '../components/StoreCard';
 
 const Stores = () => {
-  // PING
-  // useEffect(() => {
-  //   (async () => {
-  //     try {
-  //       const r = await instance.get('/stores');
-  //       console.log(
-  //         '[PING] /stores OK',
-  //         r.status,
-  //         Array.isArray(r.data) ? r.data.length : r.data
-  //       );
-  //     } catch (e) {
-  //       console.error('[PING] /stores FAIL', e);
-  //     }
-  //   })();
-  // }, []);
-
-  // 내비바 숨김
   const { setShowNavBar } = useOutletContext();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // URL에서 모든 필터 값을 가져옵니다.
+  const name = searchParams.get('name');
+  const time = searchParams.get('time');
+  const category = searchParams.get('category');
+
+  // 내비바 숨김 처리
   useEffect(() => {
-    setShowNavBar(false); // 페이지 들어올 때 숨김
-    return () => setShowNavBar(true); // 페이지 나갈 때 복구
+    setShowNavBar(false);
+    return () => setShowNavBar(true);
   }, [setShowNavBar]);
 
-  const nav = useNavigate();
-  const [params] = useSearchParams();
-  const name = params.get('name');
+  /*
+  // 🔽 나중에 실제 API를 사용할 코드 (주석 처리)
+  const {
+    data: storesFromAPI = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['stores', name, time, category], // 모든 필터 값을 key로 사용
+    queryFn: () => {
+      // 실제 API 호출 시에는 백엔드에 모든 필터를 넘겨줘야 합니다.
+      // 예: return getStoresByFilter({ name, time, category });
+      return name ? getStoresByName(name) : fetchAllStores()
+    },
+  });
 
-  //🔽 이건 API 연결용
-  // // useQuery로 데이터 가져오기
-  // const {
-  //   data: productsRaw = [],
-  //   isLoading,
-  //   error,
-  // } = useQuery({
-  //   queryKey: ['stores', name],
-  //   queryFn: () => (name.trim() ? getStoresByName(name) : fetchAllStores()),
-  //   // enabled: !!name,
-  // });
+  if (isLoading) return <div className="p-4 text-center">검색 중...</div>;
+  if (error) return <div className="p-4 text-center text-red-500">오류가 발생했습니다: {error.message}</div>;
+  */
 
-  // // 부분검색 적용
-  // const products = useMemo(() => {
-  //   if (!name) return productsRaw; // useQuery로 받은 원본 리스트
-  //   return (productsRaw ?? []).filter((p) => matches(p.name, name));
-  // }, [productsRaw, name]);
-
-  // if (isLoading) return <div className="p-4">검색 중...</div>;
-  // if (error) return <div className="p-4">ERROR</div>;
-  // if (!stores || stores.length === 0)
-  //   return (
-  //     <div className="font-Inter flex justify-center mt-[32px] text-xl">
-  //       검색 결과가 없습니다🥺
-  //     </div>
-  //   );
-
-  // 🔽 Local Mock Data 사용
+  // 🔽 Mock Data를 사용하도록 다시 변경
   const filteredStores = useMemo(() => {
-    if (!name) return stores; // 전체 Mock Data
-    return stores.filter((s) => matches(s.name, name));
-  }, [name]);
+    let filteredData = stores;
+
+    // 시간 필터
+    if (time) {
+      const [startHour] = time.split('-').map(Number);
+      filteredData = filteredData.filter((store) => {
+        const openHour = parseInt(store.openTime.split(':')[0]);
+        return openHour >= startHour && openHour < startHour + 1;
+      });
+    }
+
+    // 카테고리 필터
+    if (category) {
+      filteredData = filteredData.filter(
+        (store) => store.category === category
+      );
+    }
+
+    // 이름(검색어) 필터
+    if (name) {
+      filteredData = filteredData.filter((store) =>
+        store.name.toLowerCase().includes(name.toLowerCase())
+      );
+    }
+
+    return filteredData;
+  }, [name, time, category]);
 
   return (
-    <div className="p-6 bg-white min-h-screen ">
+    <div className="p-6 bg-white min-h-screen">
       <div className="flex flex-row items-center content-center justify-between mb-6">
         <img
           src="/Back.svg"
           alt="Back"
-          className="w-[36px] h-[36px]"
-          onClick={() => nav(-1)} // 뒤로가기
+          className="w-[36px] h-[36px] cursor-pointer"
+          onClick={() => navigate(-1)} // 뒤로가기
         />
         <p className="text-[30px]">more;ing</p>
         <img src="/Menu.png" alt="Menu" className="w-[40px] h-[40px]" />
       </div>
 
-      {/* 검색 결과 부분 */}
       <div className="flex flex-row mb-[8px] p-[6px]">
-        <p className="font-bold">{name}</p>
-        <p>의 검색 결과입니다.</p>
+        <p>검색 결과입니다.</p>
       </div>
+
       <div className="flex flex-col items-center gap-6 w-full max-w-4xl mx-auto">
-        {/* stores 배열의 각 item을 store라는 이름으로 StoreCard에 전달 */}
-        {filteredStores.map((store) => (
-          <StoreCard key={store.id} store={store} />
-        ))}
+        {filteredStores.length > 0 ? (
+          filteredStores.map((store) => (
+            <StoreCard key={store.id} store={store} />
+          ))
+        ) : (
+          <div className="font-Inter flex justify-center mt-[32px] text-xl">
+            검색 결과가 없습니다🥺
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 📜 PR의 종류

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 📝 작업 내용

- `Main.jsx`에 시간 및 카테고리 필터링을 위한 상태(state)와 핸들러 함수를 추가했습니다.
- `SearchBar.jsx`가 `Main.jsx`로부터 필터 값을 props로 받아, 검색 시 모든 필터 값을 URL 쿼리 파라미터에 담아 `/stores` 페이지로 이동시키도록 수정했습니다.
- `Stores.jsx`가 URL의 모든 쿼리 파라미터(시간, 카테고리, 검색어)를 읽어, Mock Data를 복합적으로 필터링한 최종 결과를 보여주도록 로직을 구현했습니다.

## 📸 스크린샷
<img width="566" height="899" alt="시간필터링1" src="https://github.com/user-attachments/assets/20f71a6f-7b10-4ed4-b22e-8be0247be642" />
<img width="566" height="915" alt="시간필터링2" src="https://github.com/user-attachments/assets/c6a11324-79d9-4a9e-aedd-b2229617eea6" />
<img width="555" height="903" alt="시간필터링3" src="https://github.com/user-attachments/assets/3e7f5f16-4cf0-411e-a1f9-2039b4334419" />


## 💬 리뷰어에게 남길 말

메인 페이지에서 여러 필터를 조합했을 때 `Stores` 페이지로 필터 값들이 잘 전달되는지, 그리고 `Stores` 페이지에서 그 값들을 기반으로 정확한 결과가 나오는지 중점적으로 확인 부탁드립니다!